### PR TITLE
バックアップ用S3バケットの作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2.0.20220606.1-arm64v8
 WORKDIR /root
 
 # Install tools
-RUN yum install -y procps unzip jq
+RUN yum install -y procps unzip jq tar
 
 # Install AWS-CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"

--- a/run_minecraft_server.sh
+++ b/run_minecraft_server.sh
@@ -1,6 +1,14 @@
 #!/bin/bash -e
 
-aws s3 sync s3://${BUCKET_NAME}/backup/latest/world/ world/
+# Check for zip file
+if [[ $(aws s3 ls s3://${BACKUP_BUCKET_NAME}/minecraft-server/latest/world.tar.gz | wc -c) -ne 0 ]]; then
+  echo "Restore from s3://${BACKUP_BUCKET_NAME}/minecraft-server/latest/world.tar.gz file."
+  aws s3 cp s3://${BACKUP_BUCKET_NAME}/minecraft-server/latest/world.tar.gz world.tar.gz
+  tar xf world.tar.gz
+else
+  echo "[Deprecated]: Restore from s3://${BUCKET_NAME}/backup/latest/world/ directory."
+  aws s3 sync s3://${BUCKET_NAME}/backup/latest/world/ world/
+fi
 
 # Change settings
 sed -i "s/max-tick-time=[0-9]*/max-tick-time=-1/g" server.properties

--- a/template.yaml
+++ b/template.yaml
@@ -299,6 +299,19 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub backup.${AWS::StackName}
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+        - Id: VersioningSettingForLatestMinecraftServer
+          Status: Enabled
+          Prefix: minecraft-server/latest/
+          NoncurrentVersionTransitions:
+          - StorageClass: GLACIER
+            TransitionInDays: 7
+          NoncurrentVersionExpiration:
+            NoncurrentDays: 90
+            NewerNoncurrentVersions: 10
 
   ## NLBリソースを削除している際にもRoute53のHostedZoneでドメイン登録するために
   ## 用意しているダミーS3バケット

--- a/template.yaml
+++ b/template.yaml
@@ -206,7 +206,9 @@ Resources:
         Value: enabled
   MinecraftECSTask:
     Type: AWS::ECS::TaskDefinition
-    DependsOn: MinecraftBucket
+    DependsOn:
+    - MinecraftBucket
+    - MinecraftBackupBucket
     Properties:
       Family: minecraft
       Cpu: !Ref MinecraftContainerCpuSize
@@ -229,6 +231,8 @@ Resources:
         Environment:
         - Name: BUCKET_NAME
           Value: !Ref AWS::StackName
+        - Name: BACKUP_BUCKET_NAME
+          Value: !Sub backup.${AWS::StackName}
         - !If
           - IsUsedWhiteList
           - Name: MINECRAFT_WHITE_LIST
@@ -291,6 +295,10 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref AWS::StackName
+  MinecraftBackupBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub backup.${AWS::StackName}
 
   ## NLBリソースを削除している際にもRoute53のHostedZoneでドメイン登録するために
   ## 用意しているダミーS3バケット

--- a/template.yaml
+++ b/template.yaml
@@ -312,6 +312,11 @@ Resources:
           NoncurrentVersionExpiration:
             NoncurrentDays: 90
             NewerNoncurrentVersions: 10
+        - Id: AbortIncompleteMultipartUploadForLatestMinecraftServer
+          Status: Enabled
+          Prefix: minecraft-server/latest/
+          AbortIncompleteMultipartUpload:
+            DaysAfterInitiation: 3
 
   ## NLBリソースを削除している際にもRoute53のHostedZoneでドメイン登録するために
   ## 用意しているダミーS3バケット

--- a/terminate_minecraft_server.sh
+++ b/terminate_minecraft_server.sh
@@ -7,7 +7,9 @@ kill ${MINECRAFT_PID}
 wait ${MINECRAFT_PID}
 echo "Done minecraft-server."
 
-aws s3 sync world/ s3://${BUCKET_NAME}/backup/latest/world/
+tar cfa world.tar.gz world/ --warning=no-file-changed
+aws s3 cp world.tar.gz s3://${BACKUP_BUCKET_NAME}/minecraft-server/latest/world.tar.gz
+
 aws s3 sync crash-reports/ s3://${BUCKET_NAME}/backup/latest/crash-reports/
 
 # Wait to push log to CloudWatch Logs


### PR DESCRIPTION
close #7

本システムでは、gzipによるファイル圧縮を利用します。

なお、gzip, bzip2, xzにおける圧縮時間とファイルサイズは以下の通りです。
確かにxz形式のほうが圧縮率は高いですが、gzipと比べて3%程度しか削減できないわりに、ECSサービスにおけるコンテナタイムアウトのデフォルト待機時間である30秒を大幅に超えるため、見送りました。
同様に、bzip2形式についても、gzipと比べてファイルサイズの違いは殆ど無い割に、実行時間が4倍以上もかかる（デフォルト待機時間の30秒の半分も消費してしまう）ため、見送りました。

```bash
# time tar cfa world.tar.gz world
real    0m4.256s
user    0m3.539s
sys     0m0.286s

# time tar cfa world.tar.bz2 world
real    0m17.302s
user    0m15.436s
sys     0m0.407s

# time tar cfa world.tar.xz world
real    0m40.180s
user    0m37.208s
sys     0m0.586s


# ls -alh
 80M  world.tar.bz2
 80M  world.tar.gz
 77M  world.tar.xz

# du -h world/
 101M
```