### PR TITLE
パラメーターによるメモリサイズ設定できるようにする

### DIFF
--- a/run_minecraft_server.sh
+++ b/run_minecraft_server.sh
@@ -25,6 +25,6 @@ fi
 
 trap "./terminate_minecraft_server.sh" EXIT
 
-java -Xmx1024M -Xms1024M -jar server.jar nogui
+java -Xmx${MINECRAFT_MEMORY}M -Xms${MINECRAFT_MEMORY}M -jar server.jar nogui
 
 sleep infinity

--- a/template.yaml
+++ b/template.yaml
@@ -232,6 +232,8 @@ Resources:
           Value: !Ref AWS::StackName
         - Name: BACKUP_BUCKET_NAME
           Value: !Sub backup.${AWS::StackName}
+        - Name: MINECRAFT_MEMORY
+          Value: !Ref MinecraftContainerMemorySoftLimit
         - Name: MINECRAFT_WHITE_LIST
           Value: !Ref MinecraftWhiteListString
         LogConfiguration:

--- a/template.yaml
+++ b/template.yaml
@@ -74,7 +74,6 @@ Conditions:
   IsSetCustomDomain: !Not [ !Equals [ !Ref MinecraftDomain, 'null' ] ]
   IsSetCustomSubDomain: !Not [ !Equals [ !Ref MinecraftSubDomain, 'null' ] ]
   IsReusedHostedZone: !Not [ !Equals [ !Ref MinecraftHostedZoneId, 'null' ] ]
-  IsUsedWhiteList: !Not [ !Equals [ !Ref MinecraftWhiteListString, '' ] ]
 
 
 Resources:
@@ -233,11 +232,8 @@ Resources:
           Value: !Ref AWS::StackName
         - Name: BACKUP_BUCKET_NAME
           Value: !Sub backup.${AWS::StackName}
-        - !If
-          - IsUsedWhiteList
-          - Name: MINECRAFT_WHITE_LIST
-            Value: !Ref MinecraftWhiteListString
-          - !Ref AWS::NoValue
+        - Name: MINECRAFT_WHITE_LIST
+          Value: !Ref MinecraftWhiteListString
         LogConfiguration:
           LogDriver: awslogs
           Options:


### PR DESCRIPTION
ECS側の設定はしていたが、Minecraftサーバー側の設定ができていませんでした。